### PR TITLE
Update Dockerfile.konflux with required changes

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -7,8 +7,7 @@ USER root
 # Install build tools
 # commenetd as these packges are present in ubi9
 # RUN dnf install -y gcc-c++ libstdc++ libstdc++-devel clang && dnf clean all
-RUN dnf install -y 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm' && \
-    dnf install -y gcc-c++ libstdc++ libstdc++-devel clang zeromq-devel pkgconfig && \
+RUN dnf install -y gcc-c++ libstdc++ libstdc++-devel clang zeromq-devel pkgconfig && \
     dnf clean all
 
 WORKDIR /workspace
@@ -48,9 +47,7 @@ COPY --from=builder /workspace/bin/epp /app/epp
 # Install zeromq runtime library needed by the manager.
 # The final image is UBI9, so we need epel-release-9.
 USER root
-RUN microdnf install -y dnf && \
-    dnf install -y 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm' && \
-    dnf install -y zeromq
+RUN microdnf install -y zeromq
 
 USER 65532:65532
 


### PR DESCRIPTION
Removing explicit installation of the EPEL RPM which we no longer need aswe have used it with prefetch already