### PR TITLE
  fix: use registry.access.redhat.com and add rhoai-version parameter

### DIFF
--- a/.tekton/odh-llm-d-inference-scheduler-pull-request.yaml
+++ b/.tekton/odh-llm-d-inference-scheduler-pull-request.yaml
@@ -22,6 +22,8 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: rhoai-version
+    value: "2.25.0"
   - name: additional-tags
     value:
     - 'pr-{{pull_request_number}}-into-{{target_branch}}'

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build Stage: using Go 1.25.8 image
-FROM registry.redhat.io/ubi9/go-toolset:9.7@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.7@sha256:77bfb0f283eaa3215909342c3dda940605eff5b9f72d6dc18fad1d154d172d55 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -62,7 +62,7 @@ RUN go build -mod=mod -a -o bin/epp -ldflags="-extldflags '-L$(pwd)/lib -ltokeni
 
 # Use ubi9 as a minimal base image to package the manager binary
 # Refer to https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5 for more details
-FROM registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:5c8d55e845e14343bb84994a4d0a09002621ac0393f1f2bafc8aa219606ae451
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
 
 WORKDIR /
 COPY --from=builder /workspace/bin/epp /app/epp


### PR DESCRIPTION
  Fix "image not known" error by using registry.access.redhat.com for base images and add rhoai-version parameter to pull-request pipeline                                                                        