### PR TITLE
fix: use FIPS base image for routingsidecar runtime

### DIFF
--- a/Dockerfile.sidecar.konflux
+++ b/Dockerfile.sidecar.konflux
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -tags strict
        -ldflags="${LDFLAGS} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.CommitSHA=${COMMIT_SHA} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.BuildRef=${BUILD_REF}" \
        cmd/cmd.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7@sha256:2173487b3b72b1a7b11edc908e9bbf1726f9df46a4f78fd6d19a2bab0a701f38
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:d91be7cea9f03a757d69ad7fcdfcd7849dba820110e7980d5e2a1f46ed06ea3b
 WORKDIR /
 COPY --from=builder /workspace/bin/pd-sidecar /app/pd-sidecar
 USER 65532:65532


### PR DESCRIPTION
ref https://redhat.atlassian.net/browse/RHOAIENG-58755