### PR TITLE
fix: use FIPS base image for routingsidecar runtime

### DIFF
--- a/Dockerfile.sidecar.konflux
+++ b/Dockerfile.sidecar.konflux
@@ -32,7 +32,7 @@ RUN go build -a -tags strictfipsruntime -o bin/pd-sidecar \
        -ldflags="-X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.CommitSHA=${COMMIT_SHA} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.BuildRef=${BUILD_REF}" \
        cmd/cmd.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:d91be7cea9f03a757d69ad7fcdfcd7849dba820110e7980d5e2a1f46ed06ea3b
 WORKDIR /
 COPY --from=builder /workspace/bin/pd-sidecar /app/pd-sidecar
 USER 65532:65532


### PR DESCRIPTION
ref https://redhat.atlassian.net/browse/RHOAIENG-58755