### PR TITLE
fix: bump pillow to 12.3.0 to fix jira issues

### DIFF
--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -85,9 +85,11 @@ RUN mkdir -p /usr/local/lib/python3.12/site-packages/
 COPY --from=builder /workspace/kv-cache-manager-wrapper/render_jinja_template_wrapper.py /usr/local/lib/python3.12/site-packages/
 
 # Python deps (no cache, single target) – filter out torch
+# pillow pin overridden until kv-cache-manager bumps it (CVE-2026-59204);
+# must match the version in requirements.txt used for Konflux pip prefetch
 ENV PIP_NO_CACHE_DIR=1 PIP_DISABLE_PIP_VERSION_CHECK=1
 COPY --from=builder /workspace/kv-cache-manager-wrapper/requirements.txt /tmp/requirements.txt
-RUN sed '/^torch\b/d' /tmp/requirements.txt > /tmp/requirements.notorch.txt && \
+RUN sed -e '/^torch\b/d' -e 's/^pillow==.*/pillow==12.3.0/' /tmp/requirements.txt > /tmp/requirements.notorch.txt && \
     python3.12 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3.12 -m pip install --no-cache-dir --target /usr/local/lib/python3.12/site-packages -r /tmp/requirements.notorch.txt && \
     python3.12 -m pip install --no-cache-dir --target /usr/local/lib/python3.12/site-packages PyYAML && \

--- a/Dockerfile.epp.konflux
+++ b/Dockerfile.epp.konflux
@@ -92,9 +92,11 @@ RUN mkdir -p /usr/local/lib/python3.12/site-packages/
 COPY --from=builder /workspace/kv-cache-manager-wrapper/render_jinja_template_wrapper.py /usr/local/lib/python3.12/site-packages/
 
 # Python deps (no cache, single target) – filter out torch
+# pillow pin overridden until kv-cache-manager bumps it (CVE-2026-59204);
+# must match the version in requirements.txt used for Konflux pip prefetch
 ENV PIP_NO_CACHE_DIR=1 PIP_DISABLE_PIP_VERSION_CHECK=1
 COPY --from=builder /workspace/kv-cache-manager-wrapper/requirements.txt /tmp/requirements.txt
-RUN sed '/^torch\b/d' /tmp/requirements.txt > /tmp/requirements.notorch.txt && \
+RUN sed -e '/^torch\b/d' -e 's/^pillow==.*/pillow==12.3.0/' /tmp/requirements.txt > /tmp/requirements.notorch.txt && \
     python3.12 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3.12 -m pip install --no-cache-dir --target /usr/local/lib/python3.12/site-packages -r /tmp/requirements.notorch.txt && \
     python3.12 -m pip install --no-cache-dir --target /usr/local/lib/python3.12/site-packages PyYAML && \

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 
 packaging==24.2
-pillow==11.2.1
+pillow==12.3.0
 transformers>=4.53.0
 jinja2>=2.11
 wheel==0.45.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ packaging==24.2
     #   -r requirements.in
     #   huggingface-hub
     #   transformers
-pillow==11.2.1
+pillow==12.3.0
     # via -r requirements.in
 pyyaml==6.0.3
     # via


### PR DESCRIPTION
## Summary

Bumping Pillow `11.2.1 → 12.3.0` resolves **all seven open Pillow CVE trackers** for the `odh-llm-d-inference-scheduler-rhel9` image on the rhoai-3.3 stream:

| Jira | CVE | Flaw |
|---|---|---|
| [RHOAIENG-77048](https://redhat.atlassian.net/browse/RHOAIENG-77048) | CVE-2026-59204 | DoS via crafted tiled JPEG2000 image |
| [RHOAIENG-77718](https://redhat.atlassian.net/browse/RHOAIENG-77718) | CVE-2026-59197 | Native heap out-of-bounds |
| [RHOAIENG-77424](https://redhat.atlassian.net/browse/RHOAIENG-77424) | CVE-2026-59199 | DoS via out-of-bounds read |
| [RHOAIENG-77423](https://redhat.atlassian.net/browse/RHOAIENG-77423) | CVE-2026-59200 | DoS via crafted image |
| [RHOAIENG-77384](https://redhat.atlassian.net/browse/RHOAIENG-77384) | CVE-2026-54058 | Memory disclosure / DoS |
| [RHOAIENG-77253](https://redhat.atlassian.net/browse/RHOAIENG-77253) | CVE-2026-59205 | Controlled native heap corruption |
| [RHOAIENG-58593](https://redhat.atlassian.net/browse/RHOAIENG-58593) | CVE-2026-40192 | DoS via FITS decompression bomb (vulnerable 10.3.0–12.1.1) |

The first six are fixed in 12.3.0 per the advisories; the FITS flaw is vulnerable only through 12.1.1, so 12.3.0 covers it as well.

## Where pillow comes from

The image's pillow is **not** a direct dependency of this repo's Go code. `Dockerfile.epp(.konflux)` copies `pkg/preprocessing/chat_completions/requirements.txt` out of the `llm-d-kv-cache-manager@v0.4.0` Go module (GOMODCACHE) and pip-installs it; that file pins `pillow==11.2.1`. Upstream removed this Python dependency entirely in kv-cache ≥ v0.5.0 (CGO rewrite), which is why only branches pinned to v0.4.0 are affected — bumping the module on a z-stream is not an option, so the pin is overridden at build time instead.

## Changes

- `Dockerfile.epp` / `Dockerfile.epp.konflux`: extend the existing torch-filtering `sed` to rewrite the pillow pin to 12.3.0, with a comment explaining the override
- `requirements.in` / `requirements.txt`: bump `pillow==11.2.1 → 12.3.0` so the Konflux pip prefetch (which reads the repo-root requirements.txt) stays in sync with what pip resolves inside the hermetic build — without this the hermetic build would fail

Pillow has no transitive Python dependencies, and 12.3.0 ships cp312 x86_64 wheels (`allow_binary: true` prefetch), so no other pins move.

## Verification

- `pillow==12.3.0` ≥ the fixed version for all seven advisories above
- No remaining `11.2.1` references in the repo
- Konflux build on this PR validates the hermetic prefetch/install consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)