### PR TITLE
fix: bump urllib3 to 2.7.0 to fix 2 urllib3 

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,3 +5,4 @@ transformers>=4.53.0
 jinja2>=2.11
 wheel==0.45.1
 PyYAML==6.0.3
+urllib3>=2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,9 @@ transformers==4.57.3
     # via -r requirements.in
 typing-extensions==4.15.0
     # via huggingface-hub
-urllib3==2.6.1
-    # via requests
+urllib3==2.7.0
+    # via
+    #   -r requirements.in
+    #   requests
 wheel==0.45.1
     # via -r requirements.in


### PR DESCRIPTION
## Summary

Bumping urllib3 `2.6.1 → 2.7.0` resolves **both open urllib3 CVE trackers** for the `odh-llm-d-inference-scheduler-rhel9` image on the rhoai-3.3 stream:

| Jira | CVE | Flaw |
|---|---|---|
| [RHOAIENG-64529](https://redhat.atlassian.net/browse/RHOAIENG-64529) | CVE-2026-44431 | urllib3: Information disclosure |
| [RHOAIENG-63909](https://redhat.atlassian.net/browse/RHOAIENG-63909) | CVE-2026-44432 | urllib3: Denial of Service |

Both are fixed in urllib3 2.7.0 per the advisories.

## Changes

- `requirements.txt`: `urllib3==2.6.1 → 2.7.0` — this file feeds the Konflux pip prefetch, and the hermetic build installs exactly what's prefetched, so this pin is what lands in the image
- `requirements.in`: add an explicit `urllib3>=2.7.0` floor — urllib3 is only a transitive dependency (via `requests`), so without the floor a future `pip-compile` could silently resolve back below the fixed version

No Dockerfile changes needed (unlike the pillow fix in #347): urllib3 is not pinned in the kv-cache-manager requirements that the image installs, so pip resolves it freely to the prefetched version.

urllib3 2.7.0 is a pure-Python wheel (`py3-none-any`), `requires_python >=3.10` — compatible with the image's Python 3.12, and `requests` accepts `urllib3 <3`.

## Verification

- `urllib3==2.7.0` ≥ the fixed version for both advisories
- Konflux build on this PR validates the hermetic prefetch/install consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)