### PR TITLE
use 1.26 for go-toolset builder image

### DIFF
--- a/Dockerfile.epp.konflux
+++ b/Dockerfile.epp.konflux
@@ -1,5 +1,5 @@
 # Go build stage
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5@sha256:91d07f2b7f402fe2379fd62eb2fff975c814a595e2ff2988fd7c580568f5f90c AS go-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:91d07f2b7f402fe2379fd62eb2fff975c814a595e2ff2988fd7c580568f5f90c AS go-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.sidecar.konflux
+++ b/Dockerfile.sidecar.konflux
@@ -1,5 +1,5 @@
 # Build Stage: using Go 1.26 image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5@sha256:91d07f2b7f402fe2379fd62eb2fff975c814a595e2ff2988fd7c580568f5f90c AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:91d07f2b7f402fe2379fd62eb2fff975c814a595e2ff2988fd7c580568f5f90c AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG COMMIT_SHA=unknown


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
Update go-toolset image to x.y tag per @grdryn's suggestion: https://redhat-internal.slack.com/archives/C06FYLF5DQ9/p1784672530415739?thread_ts=1779377097.487229&cid=C06FYLF5DQ9.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
